### PR TITLE
Use `dotenv` instead of manually set the path to package-config files

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+PKG_CONFIG_PATH=$HOME/ffmpeg_build/lib/pkgconfig

--- a/.env
+++ b/.env
@@ -1,1 +1,0 @@
-PKG_CONFIG_PATH=$HOME/ffmpeg_build/lib/pkgconfig

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,7 +103,7 @@ jobs:
           hash -r
           cd ..
 
-      - run: PKG_CONFIG_PATH="$HOME/ffmpeg_build/lib/pkgconfig cargo clippy -- -D warnings"
+      - run: cargo clippy -- -D warnings"
 
   build_and_test:
     runs-on: ubuntu-latest
@@ -179,7 +179,7 @@ jobs:
           hash -r
           cd ..
       - name: BindingBuild
-        run: PKG_CONFIG_PATH="$HOME/ffmpeg_build/lib/pkgconfig" cargo build --verbose
+        run: cargo build --verbose
       - name: BindingTest
         run: cargo test --verbose
       - name: BuildExamples

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ doctest = false
 once_cell = "1.4.0"
 
 [build-dependencies]
+dotenv = "0.15.0"
 bindgen = "0.54.0"
 once_cell = "1.4.0"
 pkg-config = "0.3.17"

--- a/build.rs
+++ b/build.rs
@@ -2,6 +2,7 @@
 use bindgen::{self, callbacks, CargoCallbacks};
 use once_cell::sync::{Lazy, OnceCell};
 use pkg_config as pkgconfig;
+use dotenv::dotenv;
 
 use std::{collections::HashSet, convert::From, env, fs, path};
 
@@ -114,6 +115,7 @@ fn out_dir() -> path::PathBuf {
 }
 
 fn main() {
+    dotenv().ok();
     // We currently only support building with static libraries.
 
     /* Thanks to pkg-config, we almost don't need this.

--- a/build.rs
+++ b/build.rs
@@ -1,8 +1,8 @@
 #![feature(bool_to_option)]
 use bindgen::{self, callbacks, CargoCallbacks};
+use dotenv::dotenv;
 use once_cell::sync::{Lazy, OnceCell};
 use pkg_config as pkgconfig;
-use dotenv::dotenv;
 
 use std::{collections::HashSet, convert::From, env, fs, path};
 


### PR DESCRIPTION
Fixes #8 