### PR TITLE
Fix CI warning for u128, correct clippy in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,7 +103,7 @@ jobs:
           hash -r
           cd ..
 
-      - run: PKG_CONFIG_PATH="$HOME/ffmpeg_build/lib/pkgconfig cargo clippy -- -D warnings"
+      - run: PKG_CONFIG_PATH="$HOME/ffmpeg_build/lib/pkgconfig" cargo clippy -- -D warnings
 
   build_and_test:
     runs-on: ubuntu-latest

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,8 @@
-#![allow(non_snake_case, non_camel_case_types, non_upper_case_globals)]
-#![allow(clippy::all)]
-
+#![allow(
+    non_snake_case,
+    non_camel_case_types,
+    non_upper_case_globals,
+    improper_ctypes,
+    clippy::all
+)]
 include!(concat!(env!("OUT_DIR"), "/binding.rs"));


### PR DESCRIPTION
Fixes #1 