### PR TITLE
Reorganize functions to `ffi::*` for future compatibility

### DIFF
--- a/examples/slice/main.rs
+++ b/examples/slice/main.rs
@@ -1,7 +1,7 @@
 //! Port from Original code: https://github.com/leandromoreira/ffmpeg-libav-tutorial/blob/master/0_hello_world.c
 //! Since this is a ported code, many warnings will emits.
 #![allow(non_snake_case, non_camel_case_types, non_upper_case_globals)]
-use rusty_ffmpeg::*;
+use rusty_ffmpeg::ffi::*;
 
 use libc::c_int;
 use std::{

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,10 @@
-#![allow(
+#[allow(
     non_snake_case,
     non_camel_case_types,
     non_upper_case_globals,
     improper_ctypes,
     clippy::all
 )]
-include!(concat!(env!("OUT_DIR"), "/binding.rs"));
+pub mod ffi {
+    include!(concat!(env!("OUT_DIR"), "/binding.rs"));
+}


### PR DESCRIPTION
May wrap some function around so move the raw generated functions and structs into a `ffi` module. Which is relavent to #7 .