### PR TITLE
Workaround of constantly rebuilding, bump version to 0.3.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rusty_ffmpeg"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["ldm0 <ldm2993593805@163.com>"]
 edition = "2018"
 

--- a/build.rs
+++ b/build.rs
@@ -369,10 +369,12 @@ mod windows {
 }
 
 fn main() {
+    /* Workaround of cargo rerun-if-env-changed bug
     println!("cargo:rerun-if-env-changed=DOCS_RS");
     println!("cargo:rerun-if-env-changed=VCPKG_ROOT");
     println!("cargo:rerun-if-env-changed=FFMPEG_PKG_CONFIG_PATH");
     println!("cargo:rerun-if-env-changed=FFMPEG_DYNAMIC_LINKING");
+    */
 
     let out_dir = &env::var("OUT_DIR").unwrap();
 


### PR DESCRIPTION
Reopen #29 , the crate currently always rebuilds, it's likely a bug of cargo, this is a workaround.