### PR TITLE
fix: only one triplet was getting cached

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -250,7 +250,7 @@ jobs:
         uses: friendlyanon/setup-vcpkg@v1
         with:
           committish: "2023.02.24"
-          cache-version: "1"
+          cache-version: ${{ matrix.config.vcpkg_triplet }}-1
           ignore-reserve-cache-error: true
 
       - name: Install Dependencies


### PR DESCRIPTION
This is a followup-pr as only one vcpkg's triplet was getting cached, if another was trying to get cached then it would be overriding the previous one, will test it on my github actions then merge.