### PR TITLE
changed "Linking FFmpeg..." to "Links FFmpeg..." in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 Cross platform FFI bindings for FFmpeg inner libraries. This is a crate that:
 
-1. Linking FFmpeg libraries for you.
+1. Links FFmpeg libraries for you.
 2. Generates Rust binding for FFmpeg libraries.
 
 ## Getting started:


### PR DESCRIPTION
Made a minor change to the readme that felt contextually correct.