### PR TITLE
ci: update ffmpeg branch to release/7.1 and add libbz2-dev

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -395,6 +395,41 @@ jobs:
   build_dynamic_and_test_ubuntu:
     runs-on: ubuntu-latest
     steps:
+      # https://trac.ffmpeg.org/wiki/CompilationGuide/Ubuntu
+      - name: Install FFmpegBuildTools
+        run: |
+          sudo apt-get update -qq && sudo apt-get -y install \
+            autoconf \
+            automake \
+            build-essential \
+            cmake \
+            git-core \
+            libass-dev \
+            libfreetype6-dev \
+            libgnutls28-dev \
+            libsdl2-dev \
+            libbz2-dev \
+            libtool \
+            libva-dev \
+            libvdpau-dev \
+            libvorbis-dev \
+            libxcb1-dev \
+            libxcb-shm0-dev \
+            libxcb-xfixes0-dev \
+            pkg-config \
+            texinfo \
+            wget \
+            yasm \
+            zlib1g-dev \
+            nasm \
+            libx264-dev \
+            libx265-dev \
+            libnuma-dev \
+            libvpx-dev \
+            libfdk-aac-dev \
+            libmp3lame-dev \
+            libopus-dev
+
       - name: Build x264
         # Since github actions use 2 core cpu
         run: |
@@ -717,14 +752,14 @@ jobs:
             texinfo \
             wget \
             yasm \
-            zlib1g-dev
-          sudo apt-get -y install nasm
-          sudo apt-get -y install libx264-dev
-          sudo apt-get -y install libx265-dev libnuma-dev
-          sudo apt-get -y install libvpx-dev
-          sudo apt-get -y install libfdk-aac-dev
-          sudo apt-get -y install libmp3lame-dev
-          sudo apt-get -y install libopus-dev
+            zlib1g-dev \
+            nasm \
+            libx264-dev \
+            libx265-dev libnuma-dev \
+            libvpx-dev \
+            libfdk-aac-dev \
+            libmp3lame-dev \
+            libopus-dev
 
       - name: Set env
         run: echo "DOCS_RS=1" >> $GITHUB_ENV

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -481,8 +481,6 @@ jobs:
             --enable-libx264 \
             --enable-pic \
             --disable-vaapi \
-            --disable-qsv \
-            --disable-vaapi \
             --disable-libdrm \
             --disable-vdpau \
             --disable-xlib

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -444,9 +444,6 @@ jobs:
             --enable-static \
             --enable-strip \
             --enable-pic \
-            --disable-qsv \
-            --disable-vaapi \
-            --disable-libdrm \
             --disable-asm
           make -j$(nproc)
           make install
@@ -484,6 +481,9 @@ jobs:
             --enable-libx264 \
             --enable-pic \
             --disable-vaapi \
+            --disable-qsv \
+            --disable-vaapi \
+            --disable-libdrm \
             --disable-vdpau \
             --disable-xlib
           make -j$(nproc)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,7 @@ jobs:
             cmake \
             git-core \
             libass-dev \
+            libbz2-dev \
             libfreetype6-dev \
             libgnutls28-dev \
             libsdl2-dev \
@@ -70,7 +71,7 @@ jobs:
             libopus-dev
 
       - run: |
-          git clone https://github.com/ffmpeg/ffmpeg --depth 1 --single-branch --branch release/7.0
+          git clone https://github.com/ffmpeg/ffmpeg --depth 1 --single-branch --branch release/7.1
           cd ffmpeg
           mkdir build
           cd build
@@ -289,7 +290,7 @@ jobs:
       # Disable exr,phm to workaround "multiple definition of 'ff_init_half2float_tables'"
       # Ref: `https://github.com/larksuite/rsmpeg/pull/98#issuecomment-1467511193`
       - run: |
-          git clone https://github.com/ffmpeg/ffmpeg --depth 1 --single-branch --branch release/7.0
+          git clone https://github.com/ffmpeg/ffmpeg --depth 1 --single-branch --branch release/7.1
           cd ffmpeg
           mkdir build
           cd build
@@ -415,7 +416,7 @@ jobs:
 
       - name: Build FFmpeg dylib
         run: |
-          git clone https://github.com/ffmpeg/ffmpeg --depth 1 --single-branch --branch release/7.0
+          git clone https://github.com/ffmpeg/ffmpeg --depth 1 --single-branch --branch release/7.1
           cd ffmpeg
           mkdir build
           cd build
@@ -497,7 +498,7 @@ jobs:
 
       - name: Build FFmpeg dylib
         run: |
-          git clone https://github.com/ffmpeg/ffmpeg --depth 1 --single-branch --branch release/7.0
+          git clone https://github.com/ffmpeg/ffmpeg --depth 1 --single-branch --branch release/7.1
           cd ffmpeg
           mkdir build
           cd build
@@ -584,7 +585,7 @@ jobs:
           cd ../..
       - name: Build FFmpeg
         run: |
-          git clone https://github.com/ffmpeg/ffmpeg --depth 1 --single-branch --branch release/7.0
+          git clone https://github.com/ffmpeg/ffmpeg --depth 1 --single-branch --branch release/7.1
           cd ffmpeg
           mkdir build
           cd build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -422,6 +422,7 @@ jobs:
             yasm \
             zlib1g-dev \
             nasm \
+            libdrm-dev \
             libx264-dev \
             libx265-dev \
             libnuma-dev \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -444,6 +444,7 @@ jobs:
             --enable-static \
             --enable-strip \
             --enable-pic \
+            --disable-qsv \
             --disable-asm
           make -j$(nproc)
           make install

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -445,6 +445,7 @@ jobs:
             --enable-strip \
             --enable-pic \
             --disable-qsv \
+            --disable-vaapi \
             --disable-asm
           make -j$(nproc)
           make install

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -446,6 +446,7 @@ jobs:
             --enable-pic \
             --disable-qsv \
             --disable-vaapi \
+            --disable-libdrm \
             --disable-asm
           make -j$(nproc)
           make install


### PR DESCRIPTION
Update the FFmpeg branch from release/7.0 to release/7.1 in the CI workflow to ensure compatibility with the latest stable version. Additionally, add libbz2-dev as a dependency to support bzip2 compression in the build process.