### PR TITLE
Update build.rs to remove misleading `FFMPEG_PKG_CONFIG_PATH` on Windows

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -508,7 +508,7 @@ Enable `link_vcpkg_ffmpeg` feature if you want to link ffmpeg libraries installe
             panic!(
                 "
 !!!!!!! rusty_ffmpeg: No linking method set!
-Use FFMPEG_PKG_CONFIG_PATH or FFMPEG_LIBS_DIR if you have prebuilt FFmpeg libraries.
+Use FFMPEG_LIBS_DIR if you have prebuilt FFmpeg libraries.
 Enable `link_vcpkg_ffmpeg` feature if you want to link ffmpeg provided by vcpkg.
 "
             );


### PR DESCRIPTION
It seems that `FFMPEG_PKG_CONFIG_PATH` does not work on Windows at all, but the error messages hints the user to set it.