### PR TITLE
fix: replace panicking unwrap() calls with descriptive errors in build.rs

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -417,9 +417,12 @@ fn dynamic_linking(env_vars: EnvVars) {
                         stem.trim_start_matches("lib")
                     }
                 })
-                .unwrap()
+                .expect("FFMPEG_DLL_PATH does not point to a valid file. Ensure the path includes a filename.")
                 .to_string(),
-            ffmpeg_dll_path.parent().unwrap().to_path_buf(),
+            ffmpeg_dll_path
+                .parent()
+                .expect("FFMPEG_DLL_PATH has no parent directory. Please provide a full path including the directory.")
+                .to_path_buf(),
         );
         linking_with_single_lib(&lib_name, &ffmpeg_dll_dir, FFmpegLinkMode::Dynamic);
     }


### PR DESCRIPTION
## Problem

In `dynamic_linking()` in `build.rs`, two `.unwrap()` calls can panic with an unhelpful "called unwrap() on None" message:

- `file_stem().unwrap()` panics if the path has no valid filename
- `parent().unwrap()` panics if the path has no parent directory

## Fix

Replaced both with `.expect()` to get a clear, readable message explaining what went wrong instead of a panic.

## Note

Also noticed a similar `.unwrap()` in the `vcpkg_linking` module when converting paths to UTF-8. This could potentially panic on Windows if FFmpeg is installed in a path with non-UTF-8 characters, though likely rare. Leaving it out of this PR to keep changes focused, can be addressed separately if needed.