### PR TITLE
Bump bindgen to 0.72 for LLVM 22 compatibility

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ doctest = false
 [dependencies]
 
 [build-dependencies]
-bindgen = "0.71"
+bindgen = "0.72"
 camino = "1.1"
 once_cell = "1.12"
 vcpkg = { version = "0.2", optional = true }


### PR DESCRIPTION
Bumps bindgen from 0.71 to 0.72 to fix compilation on systems with LLVM/Clang 22.

## Problem
LLVM 22 introduced a change in AST representation (llvm/llvm-project#147835) that 
causes bindgen 0.71 to incorrectly generate opaque types for several FFmpeg structs 
(e.g., `AVFormatContext`, `AVBitStreamFilter`). This makes any crate depending on 
rusty_ffmpeg fail to compile on LLVM 22 systems.

The issue was reported and fixed in bindgen 0.72.1: 
- rust-lang/rust-bindgen#3264 
- https://github.com/rust-lang/rust-bindgen/compare/v0.72.0...v0.72.1

## Testing
- Verified on LLVM 22.1.2 with FFmpeg 6.1.1 headers
- The bindgen 0.72 release is backward compatible with older LLVM versions, 
  so this should not break CI on Ubuntu with older clang